### PR TITLE
Exposing cursor

### DIFF
--- a/library/src/main/java/com/orm/SugarRecord.java
+++ b/library/src/main/java/com/orm/SugarRecord.java
@@ -373,7 +373,7 @@ public class SugarRecord {
         this.id = id;
     }
 
-    static class CursorIterator<E> implements Iterator<E> {
+    public static class CursorIterator<E> implements Iterator<E> {
         Class<E> type;
         Cursor cursor;
 
@@ -417,6 +417,19 @@ public class SugarRecord {
         public void remove() {
             throw new UnsupportedOperationException();
         }
+        
+        @Override
+        public E getItemAtPosition(int position) {
+            if(cursor.moveToPosition(position)) {
+                return this.next();
+            } else {
+                return null;
+            }
+        }
+        
+        public Cursor getCursor() {
+            return cursor;
+        }
     }
-
+    
 }


### PR DESCRIPTION
For databases that have many many rows and are trying to implement and infinite scrollview, loading everything into an ArrayList will not work. We need to use a cursor adapter.
